### PR TITLE
Strip trailing /

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ DATA_INGEST_TOKEN=<YOUR TOKEN VALUE>
 ```
 #### 3. Run the deployment script
 ```shell
-cd ..
 chmod 777 deployment.sh
 ./deployment.sh  --clustername "${NAME}" --dturl "${DT_TENANT_URL}" --dtingesttoken "${DATA_INGEST_TOKEN}" --dtoperatortoken "${API_TOKEN}"
 ```
@@ -109,20 +108,20 @@ Save the changes .
 First let's start with the cluster efficiency Dashboard :
 ```shell
 curl -X 'POST' \
-'https://bix24852.dev.dynatracelabs.com/api/config/v1/dashboards' \
+'${DT_TENANT_URL}/api/config/v1/dashboards' \
 -H 'accept: application/json; charset=utf-8' \
 -H 'Content-Type: application/json; charset=utf-8' \
--H 'Authorization: Api-Token ${API_TOKEN}'\
--d @dynatrace/Cluster efficiency.json'
+-H "Authorization: Api-Token ${API_TOKEN}" \
+-d @dynatrace/Cluster\ efficiency.json
 ```
 then the K6 dashboard:
 ```shell
 curl -X 'POST' \
-'https://bix24852.dev.dynatracelabs.com/api/config/v1/dashboards' \
+'${DT_TENANT_URL}/api/config/v1/dashboards' \
 -H 'accept: application/json; charset=utf-8' \
 -H 'Content-Type: application/json; charset=utf-8' \
--H 'Authorization: Api-Token ${API_TOKEN}'\
--d @dynatrace/K6 load test.json'
+-H "Authorization: Api-Token ${API_TOKEN}" \
+-d @dynatrace/K6\ load\ test.json
 ```
 
 #### b. Look at the dashboard "Cluster effiency"

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ metadata:
 ```
 Save the changes .
 
-### 6. Optimize the Ressources 
+### 6. Optimize the Resources 
 
 #### a. Deploy the the Dynatrace Dashboards
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ chmod 777 deployment.sh
 ./deployment.sh  --clustername "${NAME}" --dturl "${DT_TENANT_URL}" --dtingesttoken "${DATA_INGEST_TOKEN}" --dtoperatortoken "${API_TOKEN}"
 ```
 ### 5.Configure OpenCost
+The Cloud Provider API Token provided by default probably doesn't work in your GCP environment.
+Create a new API token as described in: https://www.opencost.io/docs/configuration/gcp-opencost.
+Copy the resulting API token and apply to OpenCost.
+```shell
+kubectl set env deployment/opencost CLOUD_PROVIDER_KEY=<new API token> -n openost
+```
+
 To let Dynatrace ingest the OpenCost metrics in dynatrace, we need to add the dynatrace annotations on the openCost servic/
 ```shell
 kubectl edit svc opencost -n opencost

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Save the changes .
 First let's start with the cluster efficiency Dashboard :
 ```shell
 curl -X 'POST' \
-'${DT_TENANT_URL}/api/config/v1/dashboards' \
+"${DT_TENANT_URL}/api/config/v1/dashboards" \
 -H 'accept: application/json; charset=utf-8' \
 -H 'Content-Type: application/json; charset=utf-8' \
 -H "Authorization: Api-Token ${API_TOKEN}" \
@@ -125,7 +125,7 @@ curl -X 'POST' \
 then the K6 dashboard:
 ```shell
 curl -X 'POST' \
-'${DT_TENANT_URL}/api/config/v1/dashboards' \
+"${DT_TENANT_URL}/api/config/v1/dashboards" \
 -H 'accept: application/json; charset=utf-8' \
 -H 'Content-Type: application/json; charset=utf-8' \
 -H "Authorization: Api-Token ${API_TOKEN}" \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ PROJECT_ID="<your-project-id>"
 gcloud services enable container.googleapis.com --project ${PROJECT_ID}
 gcloud services enable monitoring.googleapis.com \
 cloudtrace.googleapis.com \
-clouddebugger.googleapis.com \
 cloudprofiler.googleapis.com \
 --project ${PROJECT_ID}
 ```

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ The Cloud Provider API Token provided by default probably doesn't work in your G
 Create a new API token as described in: https://www.opencost.io/docs/configuration/gcp-opencost.
 Copy the resulting API token and apply to OpenCost.
 ```shell
-kubectl set env deployment/opencost CLOUD_PROVIDER_KEY=<new API token> -n openost
+kubectl set env deployment/opencost CLOUD_PROVIDER_KEY=<new API token> -n opencost
+kubectl rollout restart deployment/opencost -n opencost
 ```
 
 To let Dynatrace ingest the OpenCost metrics in dynatrace, we need to add the dynatrace annotations on the openCost servic/

--- a/deployment.sh
+++ b/deployment.sh
@@ -42,7 +42,7 @@ while [ $# -gt 0 ]; do
     shift 2
      ;;
    --dturl)
-     DTURL="$2"
+     DTURL="${2%/}"
     shift 2
      ;;
   --clustername)

--- a/dynatrace/Cluster efficiency.json
+++ b/dynatrace/Cluster efficiency.json
@@ -5,7 +5,6 @@
     ],
     "clusterVersion": "1.272.0.20230707-084854"
   },
-  "id": "72cc99f4-2981-4b4e-a437-5e94cd2fc728",
   "dashboardMetadata": {
     "name": "Cluster efficiency",
     "shared": false,

--- a/dynatrace/K6 load test.json
+++ b/dynatrace/K6 load test.json
@@ -5,7 +5,6 @@
     ],
     "clusterVersion": "1.272.0.20230707-084854"
   },
-  "id": "31975846-2c3c-4a96-844e-48ddfae92ebd",
   "dashboardMetadata": {
     "name": "K6 load test",
     "shared": false,


### PR DESCRIPTION
Dynatrace doesn't like extra slashes in URLs. Strip any trailing '/' from the DTURL variable that a user may include.